### PR TITLE
Add Supabase/Vercel migration spec and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,121 @@
+# AGENTS.md — virtual-agent
+
+## Mission
+
+Virtual-agent is a tour management app for music artists. It helps booking agents manage artists, tours, gigs, bookings, and technical riders.
+
+The app is a **single Next.js application** backed by **Supabase Postgres**, deployed on **Vercel**.
+
+## Repo Map
+
+```
+/
+├── app/                    # Next.js App Router pages
+│   ├── (auth)/             # Login, signup (public routes)
+│   └── (dashboard)/        # Protected routes (Dashboard, Tours, Riders, Settings)
+├── components/             # React components (shadcn/ui based)
+├── db/
+│   ├── schema/             # Drizzle ORM schemas (pgTable)
+│   ├── migrations/         # Drizzle migration files
+│   └── seed.ts             # Seed script for sample data
+├── lib/
+│   ├── supabase/           # Supabase client (browser) and server helpers
+│   └── ...                 # Shared utilities
+├── specs/features/         # Gherkin feature specs (PM goals)
+├── drizzle.config.ts       # Drizzle config targeting Supabase Postgres
+├── AGENTS.md               # This file — agent guidelines
+└── package.json
+```
+
+## Issue Creation Constraints
+
+These rules apply to the **attractor PM agent** when creating issues from a feature spec goal.
+
+### Maximum 3 Issues Per Goal
+
+- Each PM goal (feature spec) must be broken into **no more than 3 issues**.
+- Each issue should be a meaningful, shippable increment — not a micro-task.
+- If more work is needed after the 3 issues are completed, **create a new PM goal** with a new feature spec.
+
+### Visual Verification Required
+
+- Every issue **must define a visual checkpoint** — a concrete thing you can see in the browser that proves the issue was implemented correctly.
+- Include a **"Visual Verification"** section in every issue body with bullet points describing exactly what to look for.
+- If an issue has no visible browser change, it is too low-level. Combine it with another issue.
+
+Example:
+
+```markdown
+## Visual Verification
+- Navigate to /login → login form renders with email and password fields
+- Submit valid credentials → redirected to dashboard
+- Dashboard shows "Chic" as the artist name
+```
+
+### AGENTS.md Update Requirement
+
+- **After every PR**, check whether AGENTS.md needs updating.
+- If anything was wrong, unclear, missing, or could be more explicit — update AGENTS.md in the same PR or a follow-up.
+- This ensures agent instructions improve over time based on real implementation experience.
+- Common updates: new file paths, changed conventions, discovered gotchas, corrected assumptions.
+
+## Tech Stack
+
+| Layer          | Technology                          |
+| -------------- | ----------------------------------- |
+| Framework      | Next.js (App Router)                |
+| UI             | shadcn/ui + Tailwind CSS            |
+| Auth           | Supabase Auth (email/password)      |
+| Database       | Supabase Postgres                   |
+| ORM            | Drizzle ORM (`pgTable`, `pgEnum`)   |
+| Deployment     | Vercel                              |
+| Package Mgr    | npm (not Bun — Vercel compatibility)|
+
+## Coding Standards
+
+### Next.js
+
+- Use the App Router (`app/` directory), not Pages Router.
+- Default to **Server Components**. Only use `"use client"` when the component needs browser APIs, event handlers, or React hooks.
+- Use route groups `(auth)` and `(dashboard)` to separate public and protected layouts.
+- Fetch data in Server Components using the Supabase server client — avoid client-side fetching for initial page loads.
+
+### Supabase
+
+- Browser client: `lib/supabase/client.ts` — uses `createBrowserClient` from `@supabase/ssr`.
+- Server client: `lib/supabase/server.ts` — uses `createServerClient` from `@supabase/ssr` with cookie handling.
+- Auth: Use Supabase Auth middleware to protect routes. Redirect unauthenticated users to `/login`.
+- Never expose the `service_role` key in client-side code.
+
+### Drizzle ORM (Postgres)
+
+- Schemas use `pgTable` and `pgEnum` from `drizzle-orm/pg-core`.
+- Each table in its own file under `db/schema/`.
+- Barrel export from `db/schema/index.ts`.
+- Migrations generated with `drizzle-kit generate` and applied with `drizzle-kit migrate`.
+- Connection string from `DATABASE_URL` environment variable.
+
+### shadcn/ui
+
+- Install components via `npx shadcn@latest add <component>`.
+- Components live in `components/ui/`.
+- Custom components (sidebar, data tables, etc.) live in `components/`.
+- Use shadcn/ui primitives rather than building from scratch.
+
+### General
+
+- TypeScript strict mode.
+- No `any` types — use proper typing.
+- Prefer named exports over default exports.
+- Keep components small and focused.
+- Colocate related files (component + its types/utils) when practical.
+
+## Engineering Agent Workflow
+
+1. **Read the issue** — understand the visual verification criteria before writing code.
+2. **Read AGENTS.md** — follow the conventions documented here.
+3. **Read the relevant feature spec** in `specs/features/` for full context.
+4. **Implement** — write code that satisfies the issue's acceptance criteria and visual verification.
+5. **Test locally** — verify the visual checkpoint yourself before opening a PR.
+6. **Update AGENTS.md** — if you discovered anything that should be documented (new paths, gotchas, convention changes), update this file.
+7. **Open PR** — include the visual verification steps in the PR description so reviewers know what to check.

--- a/specs/features/migrate-supabase-vercel.feature
+++ b/specs/features/migrate-supabase-vercel.feature
@@ -1,0 +1,144 @@
+Feature: Migrate virtual-agent to single Next.js app with Supabase Postgres and Vercel deployment
+  As a developer contributing to virtual-agent
+  I want to collapse the Bun monorepo (Hono API + SQLite + Next.js frontend) into a single Next.js app
+  backed by Supabase Postgres and deployed on Vercel
+  So that the stack is simpler, production-ready, and leverages the org's existing Supabase Pro and Vercel accounts
+
+  Background:
+    Given the org (Guilde AI) pays for Supabase Pro and Vercel
+    And the current stack is a Bun monorepo with apps/api (Hono + SQLite) and apps/web (Next.js)
+    And there are 5 Drizzle schemas: artists, tours, gigs, bookings, riders
+
+  # ────────────────────────────────────────────────────────────────────────
+  # PM CONSTRAINTS
+  #
+  # The attractor PM must create NO MORE THAN 3 ISSUES for this goal.
+  # Every issue must produce VISIBLE CHANGES in the running app.
+  # Every issue must include a "Visual Verification" section in its body.
+  # AGENTS.md must be updated after every PR.
+  # If more work is needed after the 3 issues, create a new PM goal.
+  # ────────────────────────────────────────────────────────────────────────
+
+  # ── Issue 1 — Foundation: Single Next.js app, Supabase Auth, shadcn/ui ─
+
+  Scenario: Monorepo is collapsed into a single Next.js app at the repo root
+    Given the apps/api and apps/web directories have been removed
+    Then the repo root should contain a Next.js App Router project
+    And "package.json" should list "next", "react", and "react-dom" as dependencies
+    And the Bun workspace configuration should be removed
+
+  Scenario: Supabase Auth is configured with email/password provider
+    Given the file "lib/supabase/client.ts" exists
+    And the file "lib/supabase/server.ts" exists
+    Then the Supabase client should read NEXT_PUBLIC_SUPABASE_URL from the environment
+    And it should read NEXT_PUBLIC_SUPABASE_ANON_KEY from the environment
+
+  Scenario: Login and signup pages exist and work
+    Given the file "app/(auth)/login/page.tsx" exists
+    And the file "app/(auth)/signup/page.tsx" exists
+    Then a user can sign up with email and password
+    And a user can log in with valid credentials
+    And unauthenticated users are redirected to the login page
+
+  Scenario: shadcn/ui is installed and configured
+    Given the file "components.json" exists
+    Then shadcn/ui components should be importable
+    And Tailwind CSS should be configured for the project
+
+  Scenario: Drizzle ORM is configured for Supabase Postgres
+    Given the file "drizzle.config.ts" exists
+    Then it should configure "pg" or "postgresql" as the dialect
+    And it should reference DATABASE_URL from the environment
+
+  # Visual Verification for Issue 1:
+  #   - Navigate to the app URL → redirected to /login
+  #   - Sign up with a new email/password → account created
+  #   - Log in → redirected to the dashboard
+  #   - shadcn/ui button and input components render correctly on auth pages
+
+  # ── Issue 2 — Database: Migrate schemas to pgTable, seed data, Dashboard ─
+
+  Scenario: All 5 schemas are migrated from SQLite to Postgres pgTable
+    Given the following schema files exist under "db/schema/":
+      | file         |
+      | artists.ts   |
+      | tours.ts     |
+      | gigs.ts      |
+      | bookings.ts  |
+      | riders.ts    |
+    Then each schema should use "pgTable" from "drizzle-orm/pg-core"
+    And each schema should preserve all columns and relationships from the SQLite version
+    And enums should use "pgEnum" instead of SQLite text checks
+
+  Scenario: Drizzle migrations are generated and applied to Supabase
+    Given "package.json" has "db:generate" and "db:migrate" scripts
+    When I run "npm run db:generate"
+    Then SQL migration files should be created
+    When I run "npm run db:migrate"
+    Then all migrations should be applied to the Supabase Postgres database
+
+  Scenario: Seed script populates Supabase with sample data
+    Given "package.json" has a "db:seed" script
+    When I run "npm run db:seed"
+    Then the artists table should contain "Chic"
+    And the tours table should contain "Spring Groove Tour 2026"
+    And the gigs table should contain 5 rows across different US cities
+    And the bookings table should contain 1 flight and 1 hotel booking
+    And the riders table should contain 1 draft rider
+
+  Scenario: Dashboard page displays real data from Supabase
+    Given the user is logged in
+    When they navigate to the dashboard
+    Then the page should display the artist name "Chic"
+    And the page should display the tour name "Spring Groove Tour 2026"
+    And the page should show a summary of upcoming gigs
+
+  # Visual Verification for Issue 2:
+  #   - Log in → Dashboard loads
+  #   - Dashboard shows "Chic" as the artist
+  #   - Dashboard shows "Spring Groove Tour 2026"
+  #   - Dashboard shows gig count or upcoming gig list
+
+  # ── Issue 3 — App Shell + Deploy: Sidebar, all pages, Vercel live ──────
+
+  Scenario: App shell has a sidebar built with shadcn/ui
+    Given the file "components/sidebar.tsx" exists
+    Then the sidebar should use shadcn/ui components
+    And it should contain navigation links for:
+      | label      |
+      | Dashboard  |
+      | Tours      |
+      | Riders     |
+      | Settings   |
+
+  Scenario: All pages are wired to Supabase data
+    Then the following page files should exist:
+      | path                          |
+      | app/(dashboard)/page.tsx      |
+      | app/(dashboard)/tours/page.tsx   |
+      | app/(dashboard)/riders/page.tsx  |
+      | app/(dashboard)/settings/page.tsx |
+    And each page should fetch data from Supabase using server components or API routes
+
+  Scenario: App is deployed and live on Vercel
+    Given the project is connected to Vercel
+    And environment variables are configured in Vercel project settings:
+      | variable                       |
+      | NEXT_PUBLIC_SUPABASE_URL       |
+      | NEXT_PUBLIC_SUPABASE_ANON_KEY  |
+      | DATABASE_URL                   |
+    When a push is made to the main branch
+    Then the app should be deployed and accessible at the Vercel URL
+    And the login page should load without errors
+
+  Scenario: Protected routes require authentication
+    Given a user is not logged in
+    When they navigate to any dashboard page
+    Then they should be redirected to the login page
+
+  # Visual Verification for Issue 3:
+  #   - Open the Vercel URL → login page loads
+  #   - Log in → dashboard with sidebar appears
+  #   - Click "Tours" in sidebar → Tours page shows tour data
+  #   - Click "Riders" in sidebar → Riders page shows rider data
+  #   - Sidebar highlights the active page


### PR DESCRIPTION
## Summary
- Adds `specs/features/migrate-supabase-vercel.feature` — the PM goal spec for migrating from Bun monorepo (Hono API + SQLite + Next.js frontend) to a single Next.js app backed by Supabase Postgres, deployed on Vercel
- Adds `AGENTS.md` at repo root with issue creation constraints, coding standards for the new stack, and engineering agent workflow

## Key decisions
- PM is capped at **3 issues** per goal, each requiring a **visual verification** checkpoint
- AGENTS.md must be updated after every PR to keep agent instructions accurate
- The 3 issues: (1) Foundation — collapse monorepo + auth, (2) Database — migrate schemas + seed, (3) App shell + Vercel deploy

## Test plan
- [ ] `specs/features/migrate-supabase-vercel.feature` exists and follows Gherkin format
- [ ] `AGENTS.md` exists at repo root
- [ ] AGENTS.md explicitly caps issues at 3 per PM goal
- [ ] AGENTS.md requires visual verification per issue
- [ ] AGENTS.md requires self-update after every PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)